### PR TITLE
Switching to RSA certificates to match yast2-ca-management (bsc#694167)

### DIFF
--- a/package/yast2-ftp-server.changes
+++ b/package/yast2-ftp-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Oct 26 13:58:05 UTC 2016 - cwh@suse.com
+
+- Switch to RSA certificates to match yast2-ca-management (bsc#694167)
+- 3.2.0
+
+-------------------------------------------------------------------
 Tue Sep 20 10:40:22 UTC 2016 - jreidinger@suse.com
 
 - reduce rpm build time (bsc#999203)

--- a/package/yast2-ftp-server.spec
+++ b/package/yast2-ftp-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ftp-server
-Version:        3.1.10
+Version:        3.2.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/ftp-server/dialogs.rb
+++ b/src/include/ftp-server/dialogs.rb
@@ -1168,7 +1168,7 @@ module Yast
     end
 
 
-    # DSA Certificate to Use for SSL Encrypted Connections
+    # RSA Certificate to Use for SSL Encrypted Connections
     # Expert Settings widget
     #
     # @return [Hash{String => Object}] map for Expert screen
@@ -1201,7 +1201,7 @@ module Yast
     end
 
 
-    # "Browse" button for DSA Certificate
+    # "Browse" button for RSA Certificate
     # Expert Settings widget
     #
     # @return [Hash{String => Object}] map for Expert screen

--- a/src/include/ftp-server/helps.rb
+++ b/src/include/ftp-server/helps.rb
@@ -221,10 +221,10 @@ module Yast
             "If enabled, TLS connections are allowed.\n" +
             "</p>\n"
         ),
-        # expert settings DSA Certificate to Use for SSL Encrypted Connections help 1/1
+        # expert settings RSA Certificate to Use for SSL Encrypted Connections help 1/1
         "CertFile"          => _(
-          "<p><b>DSA Certificate to Use for SSL-encrypted Connections</b><br>\n" +
-            "This option specifies the location of the DSA certificate to \n" +
+          "<p><b>RSA Certificate to Use for SSL-encrypted Connections</b><br>\n" +
+            "This option specifies the location of the RSA certificate to \n" +
             "use for SSL-encrypted connections. Select a file by pressing <b>Browse</b>.\n" +
             "</p>\n"
         ),

--- a/src/include/ftp-server/wid_functions.rb
+++ b/src/include/ftp-server/wid_functions.rb
@@ -1616,7 +1616,7 @@ module Yast
       nil
     end
 
-    # Init function of "DSA Certificate to Use for SSL Encrypted Connections"
+    # Init function of "RSA Certificate to Use for SSL Encrypted Connections"
     # intfield
     #
     def InitCertFile(key)
@@ -1625,7 +1625,7 @@ module Yast
       nil
     end
 
-    # Valid function of "DSA Certificate to Use for SSL Encrypted Connections"
+    # Valid function of "RSA Certificate to Use for SSL Encrypted Connections"
     # check value if user enable SSL Certificate (textentry) doesn't be empty
     #
     def ValidCertFile(key, event)
@@ -1634,7 +1634,7 @@ module Yast
       ssl_enable = Convert.to_boolean(UI.QueryWidget(Id("SSLEnable"), :Value))
 
       if (rsa_cert == "" || rsa_cert == nil) && ssl_enable
-        Popup.Error(_("DSA certificate is missing."))
+        Popup.Error(_("RSA certificate is missing."))
         UI.SetFocus(Id("CertFile"))
         return false
       end
@@ -1642,7 +1642,7 @@ module Yast
       true
     end
 
-    # Store function of "DSA Certificate to Use for SSL Encrypted Connections"
+    # Store function of "RSA Certificate to Use for SSL Encrypted Connections"
     # save value to temporary structure
     #
     def StoreCertFile(key, event)
@@ -1656,7 +1656,7 @@ module Yast
     end
 
     # Handle function of "Browse"
-    # handling value in textentry of "DSA Certificate to Use for SSL Encrypted Connections"
+    # handling value in textentry of "RSA Certificate to Use for SSL Encrypted Connections"
     def HandleBrowseCertFile(key, event)
       event = deep_copy(event)
       button = Ops.get(event, "ID")

--- a/src/include/ftp-server/write_load.rb
+++ b/src/include/ftp-server/write_load.rb
@@ -1161,15 +1161,15 @@ module Yast
               if Ops.get(@EDIT_SETTINGS, "CertFile") != ""
                 Ops.set(
                   @VS_SETTINGS,
-                  "dsa_cert_file",
+                  "rsa_cert_file",
                   Ops.get(@EDIT_SETTINGS, "CertFile")
                 )
               else
-                Ops.set(@VS_SETTINGS, "dsa_cert_file", nil)
+                Ops.set(@VS_SETTINGS, "rsa_cert_file", nil)
               end
             else
-              return Builtins.haskey(@VS_SETTINGS, "dsa_cert_file") ?
-                Ops.get(@VS_SETTINGS, "dsa_cert_file") :
+              return Builtins.haskey(@VS_SETTINGS, "rsa_cert_file") ?
+                Ops.get(@VS_SETTINGS, "rsa_cert_file") :
                 Ops.get(@DEFAULT_CONFIG, "CertFile")
             end
           else


### PR DESCRIPTION
This is considered as a quick fix, since I am not sure how much effort to put in this module.
A even better fix would be to enable this module to add both, DSA and RSA certificates - but this might be worth an extra PBI.