### PR TITLE
Stub out yast2-inetd in our tests (bsc#932331)

### DIFF
--- a/package/yast2-ftp-server.changes
+++ b/package/yast2-ftp-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jan  4 17:00:41 UTC 2017 - mvidner@suse.com
+
+- Stub out yast2-inetd in our tests (bsc#932331)
+- 3.2.1
+
+-------------------------------------------------------------------
 Wed Oct 26 13:58:05 UTC 2016 - cwh@suse.com
 
 - Switch to RSA certificates to match yast2-ca-management (bsc#694167)

--- a/package/yast2-ftp-server.spec
+++ b/package/yast2-ftp-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ftp-server
-Version:        3.2.0
+Version:        3.2.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/test/ftpserver_test.rb
+++ b/test/ftpserver_test.rb
@@ -11,6 +11,7 @@ def stub_module(name)
 end
 
 stub_module("Users")
+stub_module("Inetd")
 
 Yast.import "FtpServer"
 


### PR DESCRIPTION
[bsc#932331](https://bugzilla.suse.com/show_bug.cgi?id=932331)

A fix for that bug made some previously silent errors into exceptions:

```

[   46s] + cd yast2-ftp-server-3.2.0
[   46s] + rake test:unit
[   46s] rspec --color --format doc 'test/ftpserver_test.rb'
[   47s] /usr/lib64/ruby/vendor_ruby/2.1.0/yast/yast.rb:168:in `import_pure': Failed to load Module 'FtpServer' due to: component cannot import namespace 'Inetd' (RuntimeError)
[   47s] 	from /usr/lib64/ruby/vendor_ruby/2.1.0/yast/yast.rb:168:in `import'
[   47s] 	from /home/abuild/rpmbuild/BUILD/yast2-ftp-server-3.2.0/src/include/ftp-server/write_load.rb:19:in `initialize_ftp_server_write_load'
[   47s] 	from /usr/lib64/ruby/vendor_ruby/2.1.0/yast/yast.rb:141:in `include'
[   47s] 	from /home/abuild/rpmbuild/BUILD/yast2-ftp-server-3.2.0/src/modules/FtpServer.rb:235:in `main'
[   47s] 	from /home/abuild/rpmbuild/BUILD/yast2-ftp-server-3.2.0/src/modules/FtpServer.rb:1204:in `<module:Yast>'
[   47s] 	from /home/abuild/rpmbuild/BUILD/yast2-ftp-server-3.2.0/src/modules/FtpServer.rb:5:in `<top (required)>'
[   47s] 	from /usr/lib64/ruby/vendor_ruby/2.1.0/yast/yast.rb:168:in `import_pure'
[   47s] 	from /usr/lib64/ruby/vendor_ruby/2.1.0/yast/yast.rb:168:in `import'
[   47s] 	from /home/abuild/rpmbuild/BUILD/yast2-ftp-server-3.2.0/test/ftpserver_test.rb:15:in `<top (required)>'
```