### PR TITLE
Use Docker at Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
-language: cpp
-compiler:
-    - gcc
-before_install:
-    # disable rvm, use system Ruby
-    - rvm reset
-    - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "rake yast2-devtools yast2 ruby-rspec" -g "yast-rake gettext"
-script:
-    - rake check:syntax
-    - rake check:pot
-    - rake test:unit
-    - sudo rake install
+sudo: required
+language: ruby
+services:
+  - docker
 
+before_install:
+  - docker build -t yast-inetd-image .
+script:
+  # the "yast-travis" script is included in the base yastdevel/ruby-tw image
+  # see https://github.com/yast/docker-yast-ruby-tw/blob/master/yast-travis
+  - docker run -it -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-inetd-image yast-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ services:
   - docker
 
 before_install:
-  - docker build -t yast-inetd-image .
+  - docker build -t yast-ftp-server-image .
 script:
   # the "yast-travis" script is included in the base yastdevel/ruby-tw image
   # see https://github.com/yast/docker-yast-ruby-tw/blob/master/yast-travis
-  - docker run -it -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-inetd-image yast-travis
+  - docker run -it -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-ftp-server-image yast-travis

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM yastdevel/ruby-tw
+COPY . /tmp/sources
+


### PR DESCRIPTION
~~The import failure was silently ignored. That has been fixed in the latest
yast2-core and yast2-ruby-bindings (bsc#932331).~~

~~3.2.1~~

The build dependencies were fixed in #19, I have removed that part and leave only the Docker switch here.

After switching to Docker Travis is now green :grin: 