### PR TITLE
Drop xinetd (fate#323373)

### DIFF
--- a/package/yast2-ftp-server.changes
+++ b/package/yast2-ftp-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb  8 20:58:22 UTC 2018 - knut.anderssen@suse.com
+
+- Replace CWMServiceStart xinetd methods or parameters by socket
+  ones (fate#323373)
+- 4.0.2
+
+-------------------------------------------------------------------
 Thu Feb  8 15:07:37 UTC 2018 - jreidinger@suse.com
 
 - convert starting on demand from Xinetd to systemd sockets due

--- a/package/yast2-ftp-server.spec
+++ b/package/yast2-ftp-server.spec
@@ -17,17 +17,17 @@
 
 
 Name:           yast2-ftp-server
-Version:        4.0.1
+Version:        4.0.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source0:        %{name}-%{version}.tar.bz2
 
-# SuSEFirewall2 replace by firewalld (fate#323460)
-Requires:       yast2 >= 4.0.39
+# Replace xinetd by systemd socket activation (fate#323373)
+Requires:       yast2 >= 4.0.50
 BuildRequires:  update-desktop-files
-# SuSEFirewall2 replace by firewalld (fate#323460)
-BuildRequires:  yast2 >= 4.0.39
+# Replace xinetd by systemd socket activation (fate#323373)
+BuildRequires:  yast2 >= 4.0.50
 BuildRequires:  yast2-devtools >= 3.1.10
 BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)

--- a/src/include/ftp-server/dialogs.rb
+++ b/src/include/ftp-server/dialogs.rb
@@ -132,13 +132,9 @@ module Yast
       Ops.set(
         result,
         "help",
-        Builtins.sformat(
-          CWMServiceStart.AutoStartHelpSocketTemplate,
-          _("During Boot"),
-          _("Manually"),
-          _("Via socket")
-        )
+        CWMServiceStart.AutoStartSocketHelp
       )
+
       deep_copy(result)
     end
 

--- a/src/include/ftp-server/dialogs.rb
+++ b/src/include/ftp-server/dialogs.rb
@@ -129,18 +129,14 @@ module Yast
         "set_service_start_via_socket",
         fun_ref(method(:"start_via_socket="), "void (boolean)")
       )
-      # TRANSLATORS: Radio selection
-      Ops.set(result, "start_auto_button", _("&When booting"))
-      Ops.set(result, "start_manual_button", _("&Manually"))
-      Ops.set(result, "start_socket_button", _("Via &socket"))
       Ops.set(
         result,
         "help",
         Builtins.sformat(
           CWMServiceStart.AutoStartHelpSocketTemplate,
-          _("When Booting"),
+          _("During Boot"),
           _("Manually"),
-          _("Via Socket")
+          _("Via socket")
         )
       )
       deep_copy(result)

--- a/src/include/ftp-server/dialogs.rb
+++ b/src/include/ftp-server/dialogs.rb
@@ -121,23 +121,23 @@ module Yast
       )
       Ops.set(
         result,
-        "get_service_start_via_xinetd",
+        "get_service_start_via_socket",
         fun_ref(method(:"started_via_socket?"), "boolean ()")
       )
       Ops.set(
         result,
-        "set_service_start_via_xinetd",
+        "set_service_start_via_socket",
         fun_ref(method(:"start_via_socket="), "void (boolean)")
       )
       # TRANSLATORS: Radio selection
       Ops.set(result, "start_auto_button", _("&When booting"))
       Ops.set(result, "start_manual_button", _("&Manually"))
-      Ops.set(result, "start_xinetd_button", _("Via &xinetd"))
+      Ops.set(result, "start_socket_button", _("Via &socket"))
       Ops.set(
         result,
         "help",
         Builtins.sformat(
-          CWMServiceStart.AutoStartHelpXinetdTemplate,
+          CWMServiceStart.AutoStartHelpSocketTemplate,
           _("When Booting"),
           _("Manually"),
           _("Via Socket")

--- a/src/modules/FtpServer.rb
+++ b/src/modules/FtpServer.rb
@@ -420,7 +420,7 @@ module Yast
       true
     end
 
-    # Remap UI pure-ftpd or vsftpd configuration
+    # Remap UI vsftpd configuration
     # to write structure for SCR
     #
     # @return [Boolean] successfull
@@ -868,9 +868,7 @@ module Yast
     publish_variable :modified, "boolean"
     publish_variable :proposal_valid, "boolean"
     publish_variable :vsftpd_installed, "boolean"
-    publish_variable :pureftpd_installed, "boolean"
     publish_variable :vsftpd_xined_id, "integer"
-    publish_variable :pureftpd_xined_id, "integer"
     publish_variable :create_upload_dir, "boolean"
     publish_variable :upload_good_permission, "boolean"
     publish_variable :pure_ftp_allowed_permissios_upload, "integer"


### PR DESCRIPTION
It depends on yast/yast-yast2#690

- [Trello Card](https://trello.com/c/TXqZgQhM/1325-5-remove-yast-xinetd-agent-inetd-sockets)

There is still some suspicious code mentioning pure-ftpd that probably could be removed (anon_dir permissions and creation) that probably could be dropped, I removed it and was working fine but prefer not touch it if was left there by some reason.

![ftpsocket](https://user-images.githubusercontent.com/7056681/36021022-73832aca-0d7c-11e8-849c-b7fb2158e52a.png)