### PR TITLE
Cache when the widget descriptions are really needed

### DIFF
--- a/package/yast2-ftp-server.changes
+++ b/package/yast2-ftp-server.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Apr 20 13:34:41 UTC 2018 - knut.anderssen@suse.com
+
+- bsc#1090387
+  - Do not cache widgets description until the ftp dialog is really
+    run to avoid showing an out of date firewall description (the
+    vsftpd package provides the firewalld service definition)
+- 4.0.5
+
+-------------------------------------------------------------------
 Wed Mar 21 13:09:03 UTC 2018 - mfilka@suse.com
 
 - bnc#1084434

--- a/package/yast2-ftp-server.spec
+++ b/package/yast2-ftp-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ftp-server
-Version:        4.0.4
+Version:        4.0.5
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/ftp-server/dialogs.rb
+++ b/src/include/ftp-server/dialogs.rb
@@ -24,13 +24,14 @@ module Yast
 
       Yast.include include_target, "ftp-server/helps.rb"
       Yast.include include_target, "ftp-server/wid_functions.rb"
+    end
 
-      # map for description of widget later in CWNTree
-      # widget_descr (vsftpd)
-      #
-      # @return [Hash{String,map<String => Object>}]
-
-      @wid_handling_vsftpd = {
+    # map for description of widget later in CWNTree
+    # widget_descr (vsftpd)
+    #
+    # @return [Hash{String,map<String => Object>}]
+    def wid_handling_vsftpd
+      @wid_handling_vsftpd ||= {
         "StartMode"        => CWMServiceStart.CreateAutoStartWidget(StartMode()),
         "StartStop"        => CWMServiceStart.CreateStartStopWidget(StartStop()),
         "StartStopRestart" => StartStopRestart(),
@@ -65,24 +66,27 @@ module Yast
           FirewallSettingsVs()
         )
       }
+    end
 
-      # map for screens of widget later in CWNTree
-      # screens (vsftpd)
-      #
-      # @return [Hash{String,map<String => Object>}]
-
-      @tabs_vsftpd = {
+    # map for screens of widget later in CWNTree
+    # screens (vsftpd)
+    #
+    # @return [Hash{String,map<String => Object>}]
+    def tabs_vsftpd
+      @tabs_vsftpd ||= {
         "start_up"        => start_up,
         "gen_settings"    => gen_settings,
         "perfor_settings" => perfor_settings,
         "anon_settings"   => vsftpd_anon_settings,
         "addit_settings"  => addit_settings
       }
+    end
 
-      # function for running CWNTree
-      #
-      # abort functions for confirm abort
-      #
+    # function for running CWNTree
+    #
+    # abort functions for confirm abort
+    #
+    def functions
       @functions = { abort: fun_ref(method(:AbortDialog), "boolean ()") }
     end
 
@@ -1318,12 +1322,12 @@ module Yast
 
       deep_copy(result)
     end
+
     # Init function where are added UI hadle functions
     # Expert Settings widget (vsftpd)
     # define for tabs_vsftpd necessary later in screens (CWNTree)
     #
     # @return [Hash{String => Object}] map for Expert Settings widget
-
     def addit_settings
       result = {}
 
@@ -1409,12 +1413,12 @@ module Yast
       DialogTree.ShowAndRun(
         "ids_order"      => sim_dialogs,
         "initial_screen" => "start_up",
-        "screens"        => @tabs_vsftpd,
-        "widget_descr"   => @wid_handling_vsftpd,
+        "screens"        => tabs_vsftpd,
+        "widget_descr"   => wid_handling_vsftpd,
         "back_button"    => "",
         "abort_button"   => Label.CancelButton,
         "next_button"    => Label.FinishButton,
-        "functions"      => @functions
+        "functions"      => functions
       )
     end
   end


### PR DESCRIPTION
When vsftpd is installed by ftp-server, it provides the vsftpd firewalld service definition and calls the firewalld_reload macro reloading the firewalld state.

<p align="center"> 
<img src="https://user-images.githubusercontent.com/7056681/39054962-e21fadcc-44aa-11e8-832a-75696e9b540c.png" alt="screenshot from 2018-04-20 14-47-36" style="max-width:100%;">
</p>

The problem is that ftp-server is installing the package after the widgets description has been already cached, which means it shows an out of date firewalld summary

![screenshot from 2018-04-20 14-47-18](https://user-images.githubusercontent.com/7056681/39054959-e0aa7724-44aa-11e8-8c7f-bbcb0c6737da.png)

With this fix we will cache the description once the dialog is run.

![screenshot from 2018-04-20 14-48-14](https://user-images.githubusercontent.com/7056681/39054963-e34bbe70-44aa-11e8-9a8b-885aa47f7ba5.png)
