### PR TITLE
Fix test

### DIFF
--- a/test/y2ftp/clients/ftp_server_test.rb
+++ b/test/y2ftp/clients/ftp_server_test.rb
@@ -28,6 +28,7 @@ describe Y2Ftp::Clients::FtpServer do
   describe "#FTPdCMDShow" do
     before do
       allow(Yast::FtpServer).to receive(:EDIT_SETTINGS).and_return("AnonAuthen" => anon_authen)
+      allow(Yast::FtpServer).to receive(:main)
 
       allow(Yast::CommandLine).to receive(:Print)
     end


### PR DESCRIPTION
Tests in https://github.com/yast/yast-ftp-server/pull/57 are failing for s390. Mocking unnecessary module importation for tests.