### PR TITLE
Fix fileutils

### DIFF
--- a/package/yast2-ftp-server.changes
+++ b/package/yast2-ftp-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Dec 30 16:11:40 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
+
+- fix crash with undefined method mkdir (bsc#1158421)
+- 4.2.3
+
+-------------------------------------------------------------------
 Thu Oct  3 10:45:18 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix autoyast client (bsc#1149932)

--- a/package/yast2-ftp-server.spec
+++ b/package/yast2-ftp-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ftp-server
-Version:        4.2.2
+Version:        4.2.3
 Release:        0
 Summary:        YaST2 - FTP configuration
 License:        GPL-2.0-only

--- a/src/include/ftp-server/wid_functions.rb
+++ b/src/include/ftp-server/wid_functions.rb
@@ -20,7 +20,6 @@ module Yast
       Yast.import "Service"
       Yast.import "Users"
       Yast.import "Mode"
-      Yast.import "FileUtils"
       Yast.import "Label"
       Yast.import "FtpServer"
 

--- a/src/modules/FtpServer.rb
+++ b/src/modules/FtpServer.rb
@@ -518,19 +518,19 @@ module Yast
 
         dir = @anon_homedir + upload
 
-        if !File.exist?(dir)
-          FileUtils.mkdir(dir)
-          FileUtils.chown(user, user, dir) if user
+        if !::File.exist?(dir)
+          ::FileUtils.mkdir(dir)
+          ::FileUtils.chown(user, user, dir) if user
         end
 
-        FileUtils.chmod(0o766, dir)
+        ::FileUtils.chmod(0o766, dir)
       end
       # restart/reaload daemons...
       Service.restart("vsftpd") if Service.active?("vsftpd")
 
       # update permissions for home directory if upload is enabled...
       if @pure_ftp_allowed_permissios_upload != -1 && @change_permissions
-        FileUtils.chmod(0o755, @anon_homedir)
+        ::FileUtils.chmod(0o755, @anon_homedir)
       end
 
       true


### PR DESCRIPTION
bsc: https://bugzilla.suse.com/show_bug.cgi?id=1158421

issue: during shell execution hardening native ruby methods is used, but it collides with Yast namespace.

Solution: use `::` namespace for explicitelly call global module.

unit test missing due to hard testability ( need serious rewrite to make it easier testable ).