### PR TITLE
Add yast2-users dependency

### DIFF
--- a/package/yast2-ftp-server.changes
+++ b/package/yast2-ftp-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun  2 14:20:43 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Add missing dependency of yast2-users (bsc#1132116).
+- 4.1.9
+
+-------------------------------------------------------------------
 Thu Oct  3 10:45:18 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix autoyast client (bsc#1149932)

--- a/package/yast2-ftp-server.spec
+++ b/package/yast2-ftp-server.spec
@@ -25,6 +25,10 @@ Source0:        %{name}-%{version}.tar.bz2
 
 # Yast2::Systemd::Service
 Requires:       yast2 >= 4.1.3
+Requires:       yast2-ruby-bindings >= 1.0.0
+# Do not log passwords
+Requires:       yast2-users >= 4.1.14
+
 BuildRequires:  update-desktop-files
 # Yast2::Systemd::Service
 BuildRequires:  yast2 >= 4.1.3
@@ -33,8 +37,6 @@ BuildRequires:  rubygem(%rb_default_ruby_abi:rspec)
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 
 BuildArch:      noarch
-
-Requires:       yast2-ruby-bindings >= 1.0.0
 
 Summary:        YaST2 - FTP configuration
 License:        GPL-2.0-only

--- a/package/yast2-ftp-server.spec
+++ b/package/yast2-ftp-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ftp-server
-Version:        4.1.8
+Version:        4.1.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
## Problem

*yast2-ftp-server* requires `Users` module but that dependency is totally missing in the spec file.

* https://bugzilla.suse.com/show_bug.cgi?id=1132116
* https://trello.com/c/K75J72ID/1881-sle15-p3-1132116-internal-error-yast2-ftp-server-fails-to-start-if-yast2-users-is-not-installed-on-sle15

## Solution

Added dependency of *yast2-users* package.

Note: This dependency is not needed for testing (`BuildRequires`) because a stub version of `Users` module is used for testing (i.e., `stub_module("Users")`). 