### PR TITLE
Fix certificate input label

### DIFF
--- a/package/yast2-ftp-server.changes
+++ b/package/yast2-ftp-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun  9 07:11:51 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the label of the certificate input field (bsc#1183786).
+- 4.0.8
+
+-------------------------------------------------------------------
 Thu Jun 28 14:53:32 CEST 2018 - schubi@suse.de
 
 - Added additional searchkeys to desktop file (fate#321043).

--- a/package/yast2-ftp-server.spec
+++ b/package/yast2-ftp-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ftp-server
-Version:        4.0.7
+Version:        4.0.8
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/ftp-server/dialogs.rb
+++ b/src/include/ftp-server/dialogs.rb
@@ -909,7 +909,7 @@ module Yast
       Ops.set(
         result,
         "label",
-        _("D&SA Certificate to Use for SSL-encrypted Connections")
+        _("R&SA Certificate to Use for SSL-encrypted Connections")
       )
       Ops.set(result, "widget", :textentry)
       Ops.set(result, "init", fun_ref(method(:InitCertFile), "void (string)"))


### PR DESCRIPTION
The label for the certificate field mentioned *DSA*, but the file path was saved to the `rsa_cert_file` field. See [bsc#1183786](https://bugzilla.suse.com/show_bug.cgi?id=1183786) for further information.