### PR TITLE
Fix certificate input label

### DIFF
--- a/package/yast2-ftp-server.changes
+++ b/package/yast2-ftp-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jun  9 07:11:51 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix the label of the certificate input field (bsc#1183786).
+- 4.4.1
+
+-------------------------------------------------------------------
 Tue Apr 20 13:51:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 4.4.0 (bsc#1185510)

--- a/package/yast2-ftp-server.spec
+++ b/package/yast2-ftp-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ftp-server
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 Summary:        YaST2 - FTP configuration
 License:        GPL-2.0-only

--- a/src/include/ftp-server/dialogs.rb
+++ b/src/include/ftp-server/dialogs.rb
@@ -808,7 +808,7 @@ module Yast
       Ops.set(
         result,
         "label",
-        _("D&SA Certificate to Use for SSL-encrypted Connections")
+        _("R&SA Certificate to Use for SSL-encrypted Connections")
       )
       Ops.set(result, "widget", :textentry)
       Ops.set(result, "init", fun_ref(method(:InitCertFile), "void (string)"))


### PR DESCRIPTION
The label for the certificate field mentioned *DSA*, but the file path was saved to the `rsa_cert_file` field. See [bsc#1183786](https://bugzilla.suse.com/show_bug.cgi?id=1183786) for further information.