### PR TITLE
bsc#1200399: add dependency on yast2-users

### DIFF
--- a/package/yast2-ftp-server.changes
+++ b/package/yast2-ftp-server.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun 10 12:04:04 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add the missing dependency on yast2-users to the spec file
+  (bsc#1200399).
+- 4.0.9
+
+-------------------------------------------------------------------
 Wed Jun  9 07:11:51 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix the label of the certificate input field (bsc#1183786).

--- a/package/yast2-ftp-server.spec
+++ b/package/yast2-ftp-server.spec
@@ -35,6 +35,8 @@ BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 BuildArch:      noarch
 
 Requires:       yast2-ruby-bindings >= 1.0.0
+# bsc#1200399
+Requires:       yast2-users
 
 Summary:        YaST2 - FTP configuration
 License:        GPL-2.0

--- a/package/yast2-ftp-server.spec
+++ b/package/yast2-ftp-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ftp-server
-Version:        4.0.8
+Version:        4.0.9
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
## Problem

The dependency on yast2-users is missing.

- https://bugzilla.suse.com/show_bug.cgi?id=1200399

This dependency was included in `SP1` to address a security problem in yast2-users (see https://github.com/yast/yast-ftp-server/pull/69 and [bsc#1141017](https://bugzilla.suse.com/show_bug.cgi?id=1141017)). However, such a problem is not present in GA.

## Solution

Just add the dependency.